### PR TITLE
Add browser drawing demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,11 @@ python3 src/pong.py
 ```
 
 The program will run for a short period and display the score at the end.
+
+## Drawing Shapes in the Browser
+
+A small HTML/JavaScript demo allows you to draw rectangles or squares using the mouse.
+Hold the **Shift** key while dragging to constrain the shape to a square.
+The current width and height are displayed while you draw.
+
+Open the demo by opening `src/draw/index.html` in a web browser.

--- a/src/draw/app.js
+++ b/src/draw/app.js
@@ -1,0 +1,56 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+const dims = document.getElementById('dims');
+
+let isDrawing = false;
+let startX = 0;
+let startY = 0;
+
+function drawPreview(x, y, square) {
+  const width = x - startX;
+  const height = y - startY;
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.putImageData(savedImage, 0, 0);
+  let w = width;
+  let h = height;
+  if (square) {
+    const size = Math.min(Math.abs(width), Math.abs(height));
+    w = width < 0 ? -size : size;
+    h = height < 0 ? -size : size;
+  }
+  ctx.strokeRect(startX, startY, w, h);
+  dims.style.left = (startX + w + 5) + 'px';
+  dims.style.top = (startY + h + 5) + 'px';
+  dims.textContent = `${Math.abs(w)} x ${Math.abs(h)}`;
+  dims.style.display = 'block';
+}
+
+let savedImage = ctx.getImageData(0, 0, canvas.width, canvas.height);
+
+canvas.addEventListener('mousedown', (e) => {
+  startX = e.offsetX;
+  startY = e.offsetY;
+  savedImage = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  isDrawing = true;
+});
+
+canvas.addEventListener('mousemove', (e) => {
+  if (!isDrawing) return;
+  drawPreview(e.offsetX, e.offsetY, e.shiftKey);
+});
+
+canvas.addEventListener('mouseup', (e) => {
+  if (!isDrawing) return;
+  drawPreview(e.offsetX, e.offsetY, e.shiftKey);
+  isDrawing = false;
+  dims.style.display = 'none';
+  savedImage = ctx.getImageData(0, 0, canvas.width, canvas.height);
+});
+
+canvas.addEventListener('mouseleave', () => {
+  if (isDrawing) {
+    ctx.putImageData(savedImage, 0, 0);
+    isDrawing = false;
+    dims.style.display = 'none';
+  }
+});

--- a/src/draw/index.html
+++ b/src/draw/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Draw Shapes</title>
+  <style>
+    body { margin: 0; display: flex; justify-content: center; align-items: center; height: 100vh; background: #f0f0f0; }
+    #canvas { background: #fff; border: 1px solid #ccc; cursor: crosshair; }
+    #dims { position: absolute; background: rgba(0,0,0,0.7); color: #fff; padding: 2px 4px; font-size: 12px; pointer-events: none; display: none; }
+  </style>
+</head>
+<body>
+  <div id="dims"></div>
+  <canvas id="canvas" width="800" height="600"></canvas>
+  <script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add simple HTML canvas drawing tool
- show dimensions during mouse drag
- document usage in README

## Testing
- `python3 -m py_compile src/pong.py`


------
https://chatgpt.com/codex/tasks/task_e_6861caf924f88327b73c1e9cdb93305e