### PR TITLE
Add simple claw machine game

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,3 @@
-# Ethan's Crane Game
+# Claw Machine Game
 
-Open `index.html` in your web browser to play the game. Use the arrow keys to
-move the crane and the space bar to activate the claw. Try to grab a stuffed
-seal from the machine covered in graffiti. Background electronic tones will play
-while you attempt to win.
+Use the arrow keys to position the claw and press the **space bar** to drop it. If the claw lands close to a plush seal, you'll win about one out of every three times. The background shows moving graffiti colors and a short sound plays with each attempt.

--- a/index.html
+++ b/index.html
@@ -1,13 +1,14 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Ethan's Crane Game</title>
-<link rel="stylesheet" href="style.css">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Claw Machine Game</title>
+    <link rel="stylesheet" href="style.css">
 </head>
 <body>
-<canvas id="gameCanvas" width="800" height="600"></canvas>
-<script src="script.js"></script>
+    <canvas id="gameCanvas" width="600" height="600"></canvas>
+
+    <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,146 +1,126 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 
-const width = canvas.width;
-const height = canvas.height;
-
-const crane = {
-    x: width / 2,
-    y: 50,
-    size: 40,
-    holding: null
-};
-
-const items = [];
-const numItems = 6;
-const itemSize = 30;
-
-for (let i = 0; i < numItems; i++) {
-    items.push({
-        x: Math.random() * (width - itemSize) + itemSize / 2,
-        y: Math.random() * (height - 200) + 200,
-        caught: false
-    });
-}
-
+const clawWidth = 40;
+const clawHeight = 20;
+let clawX = canvas.width / 2;
+let clawY = 50;
+let dropping = false;
+let dropProgress = 0;
 let attempts = 0;
-let successes = 0;
-let message = '';
+let wins = 0;
 
-const bgOsc = new (window.AudioContext || window.webkitAudioContext)();
-function startBackgroundMusic() {
-    const oscillator = bgOsc.createOscillator();
-    const gain = bgOsc.createGain();
-    oscillator.type = 'sawtooth';
-    oscillator.frequency.value = 220;
-    gain.gain.value = 0.05;
-    oscillator.connect(gain).connect(bgOsc.destination);
-    oscillator.start();
-    oscillator.stop(bgOsc.currentTime + 1000);
-}
-startBackgroundMusic();
+const seals = [];
+const sealRadius = 20;
+const maxSeals = 5;
 
-function playSound(win) {
-    const ctxx = new (window.AudioContext || window.webkitAudioContext)();
-    const osc = ctxx.createOscillator();
-    const gain = ctxx.createGain();
-    osc.frequency.value = win ? 880 : 110;
-    osc.type = 'triangle';
-    gain.gain.value = 0.2;
-    osc.connect(gain).connect(ctxx.destination);
-    osc.start();
-    osc.stop(ctxx.currentTime + 0.3);
-}
-
-function drawGraffiti() {
-    for (let i = 0; i < 100; i++) {
-        ctx.strokeStyle = `hsl(${Math.random()*360}, 100%, 50%)`;
-        ctx.beginPath();
-        ctx.moveTo(Math.random()*width, Math.random()*height);
-        ctx.lineTo(Math.random()*width, Math.random()*height);
-        ctx.stroke();
+function initSeals() {
+    for (let i = 0; i < maxSeals; i++) {
+        const x = 80 + Math.random() * (canvas.width - 160);
+        const y = canvas.height - 80 - Math.random() * 40;
+        seals.push({ x, y, caught: false });
     }
-    ctx.fillStyle = 'white';
-    ctx.font = 'bold 24px sans-serif';
-    ctx.fillText("Ethan's Crane Game", width/2 - 120, 40);
 }
 
-drawGraffiti();
-
-function draw() {
-    ctx.clearRect(0, 0, width, height);
-    drawGraffiti();
-
-    // Draw items
+function drawMachine() {
     ctx.fillStyle = '#ccc';
-    items.forEach(item => {
-        if (!item.caught) {
-            ctx.beginPath();
-            ctx.ellipse(item.x, item.y, itemSize/2, itemSize/2, 0, 0, Math.PI * 2);
-            ctx.fillStyle = '#eee';
-            ctx.fill();
-            ctx.fillStyle = '#000';
-            ctx.fillText('seal', item.x - 12, item.y + 4);
+    ctx.fillRect(100, 80, canvas.width - 200, canvas.height - 160);
+    ctx.strokeStyle = '#333';
+    ctx.lineWidth = 4;
+    ctx.strokeRect(100, 80, canvas.width - 200, canvas.height - 160);
+}
+
+function drawSeals() {
+    seals.forEach(seal => {
+        if (!seal.caught) {
+            const img = getSealImage();
+            ctx.drawImage(img, seal.x - sealRadius, seal.y - sealRadius, sealRadius * 2, sealRadius * 2);
         }
     });
-
-    // Draw crane arm
-    ctx.strokeStyle = '#0ff';
-    ctx.lineWidth = 5;
-    ctx.beginPath();
-    ctx.moveTo(width/2, 0);
-    ctx.lineTo(crane.x, crane.y - crane.size/2);
-    ctx.stroke();
-
-    // Draw claw
-    ctx.beginPath();
-    ctx.moveTo(crane.x - crane.size/2, crane.y);
-    ctx.lineTo(crane.x + crane.size/2, crane.y);
-    ctx.moveTo(crane.x - crane.size/2, crane.y);
-    ctx.lineTo(crane.x - crane.size/2, crane.y + crane.size);
-    ctx.moveTo(crane.x + crane.size/2, crane.y);
-    ctx.lineTo(crane.x + crane.size/2, crane.y + crane.size);
-    ctx.stroke();
-
-    // Message
-    ctx.fillStyle = 'yellow';
-    ctx.fillText(message, 20, height - 20);
 }
 
-draw();
+function drawClaw() {
+    ctx.fillStyle = '#666';
+    ctx.fillRect(clawX - clawWidth / 2, clawY - clawHeight, clawWidth, clawHeight);
+    ctx.fillRect(clawX - 5, 0, 10, clawY - clawHeight);
+}
 
-function attemptCatch() {
+function getSealImage() {
+    if (!getSealImage.cache) {
+        const img = new Image();
+        img.src = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAQAAAAAYLlVAAAAVUlEQVR42u3TMQ0AAAgDILV/51G4oKAKJEg24Rjve5XEAQcABIfAERHwoOiAgiCvAAAEIEscUZgGfV5ABABAANAHQAAVBXgA0APkEBADFoAIBAcIATiMpQ+iy52cAAAAASUVORK5CYII=';
+        getSealImage.cache = img;
+    }
+    return getSealImage.cache;
+}
+
+function playSound() {
+    const audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+    const oscillator = audioCtx.createOscillator();
+    const gainNode = audioCtx.createGain();
+    oscillator.type = 'square';
+    oscillator.frequency.setValueAtTime(220, audioCtx.currentTime);
+    oscillator.connect(gainNode);
+    gainNode.connect(audioCtx.destination);
+    oscillator.start();
+    gainNode.gain.exponentialRampToValueAtTime(0.0001, audioCtx.currentTime + 0.5);
+}
+
+function update() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawMachine();
+    drawSeals();
+    if (dropping) {
+        dropProgress += 5;
+        clawY = 50 + dropProgress;
+        if (clawY >= canvas.height - 100) {
+            checkCatch();
+            dropping = false;
+            clawY = 50;
+            dropProgress = 0;
+        }
+    }
+    drawClaw();
+    requestAnimationFrame(update);
+}
+
+function checkCatch() {
     attempts++;
-    let success = Math.random() < 0.25;
-    items.forEach(item => {
-        if (!item.caught && Math.abs(item.x - crane.x) < itemSize && Math.abs(item.y - crane.y) < itemSize) {
-            if (success) {
-                item.caught = true;
-                successes++;
+    const threshold = 30;
+    for (const seal of seals) {
+        if (!seal.caught) {
+            const dx = seal.x - clawX;
+            const dy = seal.y - (canvas.height - 100);
+            const distance = Math.sqrt(dx * dx + dy * dy);
+            if (distance < threshold) {
+                if (Math.random() < 0.33) {
+                    seal.caught = true;
+                    wins++;
+                    playSound();
+                    alert('You won! Total wins: ' + wins + '/' + attempts);
+                } else {
+                    playSound();
+                    alert('Close! Try again.');
+                }
+                return;
             }
         }
-    });
-    message = success ? 'You won a seal!' : 'No luck!';
-    playSound(success);
+    }
+    playSound();
+    alert('Miss!');
 }
 
-document.addEventListener('keydown', (e) => {
-    switch (e.key) {
-        case 'ArrowLeft':
-            crane.x = Math.max(crane.x - 20, crane.size/2);
-            break;
-        case 'ArrowRight':
-            crane.x = Math.min(crane.x + 20, width - crane.size/2);
-            break;
-        case 'ArrowUp':
-            crane.y = Math.max(crane.y - 20, crane.size/2 + 40);
-            break;
-        case 'ArrowDown':
-            crane.y = Math.min(crane.y + 20, height - crane.size);
-            break;
-        case ' ':
-            attemptCatch();
-            break;
+window.addEventListener('keydown', (e) => {
+    if (e.key === 'ArrowLeft') {
+        clawX = Math.max(120, clawX - 20);
+    } else if (e.key === 'ArrowRight') {
+        clawX = Math.min(canvas.width - 120, clawX + 20);
+    } else if (e.key === ' ') {
+        if (!dropping) {
+            dropping = true;
+        }
     }
-    draw();
 });
+
+initSeals();
+update();

--- a/style.css
+++ b/style.css
@@ -1,17 +1,20 @@
 body {
     margin: 0;
-    background: #111;
-    color: #fff;
     display: flex;
+    height: 100vh;
     justify-content: center;
     align-items: center;
-    height: 100vh;
-    font-family: sans-serif;
-    overflow: hidden;
+    background: repeating-linear-gradient(45deg, #ff4e50, #ff4e50 10px, #f9d423 10px, #f9d423 20px, #24fe41 20px, #24fe41 30px, #3f5efb 30px, #3f5efb 40px);
+    background-size: 200% 200%;
+    animation: graffiti 10s linear infinite;
+}
+
+@keyframes graffiti {
+    0% {background-position: 0 0;}
+    100% {background-position: 400px 400px;}
 }
 
 canvas {
-    background: #222;
-    border: 5px solid #555;
-    box-shadow: 0 0 20px #f0f;
+    border: 5px solid #333;
+    background: rgba(255,255,255,0.9);
 }


### PR DESCRIPTION
## Summary
- wiped previous repo contents
- created claw machine web game with graffiti background
- arrow keys move the claw, space bar drops it
- probability of winning about one out of three if near a seal
- simple audio feedback and placeholder seal images

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68759187684c8327b0e0375ea0ab2743