### PR TITLE
Update seal caption behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -14,6 +14,7 @@ const radius = 20;
 const thickness = 12;
 
 let stackCount = 0;
+let captionEndTime = 0;
 
 function drawConveyor() {
     ctx.fillStyle = '#555';
@@ -65,8 +66,10 @@ function drawSeal() {
     ctx.arc(baseX + 50, baseY - 55, 6, 0, Math.PI * 2);
     ctx.fill();
 
-    ctx.font = '20px sans-serif';
-    ctx.fillText('More pancakes!', baseX - 40, baseY - 90);
+    if (Date.now() <= captionEndTime) {
+        ctx.font = '20px sans-serif';
+        ctx.fillText('More pancakes!', baseX - 40, baseY - 90);
+    }
 }
 
 function drawPancake(p) {
@@ -101,6 +104,7 @@ function updatePancakes() {
             } else {
                 p.y = targetY;
                 p.stage = 'stacked';
+                captionEndTime = Date.now() + 5000;
             }
         }
     });


### PR DESCRIPTION
## Summary
- only show the seal's caption when a pancake lands on the plate
- hide the caption after 5 seconds

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687d1a84c5dc83278e12027af1547366